### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tabview like neteasy news app(网易新闻), 懂球帝 app. you can scroll top
 # Installation
 
 There are tow ways to use TopScrollTabView in your project:
-1, using Cocoapods;
+1, using CocoaPods;
 2, copying TSTView.h,TSTView.m,NSLayoutConstraint+Util.h,NSLayoutConstraint+Util.m to your project.
 
 通过两种方式进行集成：


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
